### PR TITLE
POM: fix scm URL

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
 		<connection>scm:git:git://github.com/PaluchLabUCL/DeformingMesh3D</connection>
 		<developerConnection>scm:git:git@github.com:PaluchLabUCL/DeformingMesh3D</developerConnection>
 		<tag>HEAD</tag>
-		<url>https://github.com/PaluchLabUCL/DeformingMesh3D</url>
+		<url>https://github.com/PaluchLabUCL/DeformingMesh3D-plugin</url>
 	</scm>
 	<issueManagement>
 		<system>GitHub Issues</system>


### PR DESCRIPTION
This permits the CI workflow to deploy to the SciJava maven repository (the url parameter needs to match the repository URL where the action is run).

(@odinsbane note that for the release version deployment to work properly, you should never change the version tag in the POM to a non-SNAPSHOT version, but instead use `release-version.sh` from `scijava-scripts` which will take care of creating a unique release tag with that version, while the `master` branch will always have SNAPSHOT versions.)